### PR TITLE
Gaugebasistuned

### DIFF
--- a/AmplitudeBasis.m
+++ b/AmplitudeBasis.m
@@ -391,7 +391,7 @@ KeyMap[Map[If[OddQ[nt],MapAt[TransposeYng,#,2],#]&],Association[Rule@@@Tally[Thr
 ]
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Gauge Group Factor*)
 
 
@@ -642,10 +642,10 @@ ranktemp=0;
 ntarget=SUNrepPartlist[[i,2]];
 Do[
 Do[
-stemp=Expand[(PermuteYBasis[ybs,YTs]/.Sortarg[tasList[group]])*convert];
+stemp=Expand[2*Expand[(PermuteYBasis[ybs,YTs]/.Sortarg[tasList[group]])*convert]];
 If[stemp==0,Continue[]];
 vtemp=SymbolicTC[stemp,WithIndex->False]/.tVal[group];
-coordtemp=LinearSolve[mbasis["basis"]\[Transpose],Flatten[vtemp]];
+coordtemp=LinearSolve[mbasis["basis"]\[Transpose],Flatten[vtemp/2]];
 AppendTo[tempresult,coordtemp];
 If[ranktemp+1==MatrixRank[tempresult],ranktemp+=1;If[ranktemp==ntarget,Break[];];,tempresult=Drop[tempresult,-1];]
 ,{YTs,SubYTs[[i]]}

--- a/Code/LieAlgebra.m
+++ b/Code/LieAlgebra.m
@@ -413,7 +413,7 @@ Return[temp*(Times@@(AuxNum[group,#,chainmap,hierarchy]&/@hierarchy[part]))]
 
 FindRepPathPartition[group_,replist_,partition_]:=Module[{hierarchy=Association[],n=Length[replist],temp1,linkedmap=Association[],result={},chainmap},temp1=UnionFinder[partition];If[Union@@temp1[[1;;All,1]]==Range[n],AppendTo[hierarchy,Range[n]->temp1[[1;;All,1]]],Print["Not a Good Partition"];Abort[];];(HierarchyFinder[hierarchy,#1]&)/@temp1;FindRepPathV3[linkedmap,group,replist,Range[n]->Singlet[group],hierarchy];
 AuxResolve2[result,linkedmap,{Range[n]->Singlet[group]},{},hierarchy];
-result=KeySelect[#,Function[x,Length@x>1]]&/@result;
+result=KeySelect[#,Function[x,Cases[partition,x]!={}]]&/@result;
 Print[result];Do[chainmap=result[[i]];MapThread[(chainmap[{#1}]=#2)&,{Range[n],replist}];result[[i]]=result[[i]]->Times@@(AuxNum[group,#1,chainmap,hierarchy]&)/@temp1[[1;;All,1]];,{i,Length[result]}];result];
 
 

--- a/Code/LieAlgebra.m
+++ b/Code/LieAlgebra.m
@@ -327,7 +327,7 @@ unflatten[result,tdim]
 
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*JBasis related*)
 
 
@@ -411,18 +411,10 @@ Return[temp*(Times@@(AuxNum[group,#,chainmap,hierarchy]&/@hierarchy[part]))]
 ];
 ]
 
-FindRepPathPartition[group_,replist_,partition_]:=Module[{hierarchy=<||>,n=Length@replist,temp1,linkedmap=<||>,result={},chainmap},
-temp1=UnionFinder[partition];
-If[Union@@temp1[[1;;,1]]==Range[n],AppendTo[hierarchy,Range[n]->temp1[[1;;,1]]],Print["Not a Good Partition"];Abort[];];
-HierarchyFinder[hierarchy,#]&/@temp1;
-FindRepPathV3[linkedmap,group,replist,Range[n]->Singlet[group],hierarchy];
+FindRepPathPartition[group_,replist_,partition_]:=Module[{hierarchy=Association[],n=Length[replist],temp1,linkedmap=Association[],result={},chainmap},temp1=UnionFinder[partition];If[Union@@temp1[[1;;All,1]]==Range[n],AppendTo[hierarchy,Range[n]->temp1[[1;;All,1]]],Print["Not a Good Partition"];Abort[];];(HierarchyFinder[hierarchy,#1]&)/@temp1;FindRepPathV3[linkedmap,group,replist,Range[n]->Singlet[group],hierarchy];
 AuxResolve2[result,linkedmap,{Range[n]->Singlet[group]},{},hierarchy];
-Do[chainmap=result[[i]];
-MapThread[Set[chainmap[{#1}],#2]&,{Range[n],replist}];
-result[[i]]=result[[i]]->Times@@(AuxNum[group,#,chainmap,hierarchy]&/@temp1[[1;;,1]]);
-,{i,Length@result}];
-result
-]
+result=KeySelect[#,Function[x,Length@x>1]]&/@result;
+Print[result];Do[chainmap=result[[i]];MapThread[(chainmap[{#1}]=#2)&,{Range[n],replist}];result[[i]]=result[[i]]->Times@@(AuxNum[group,#1,chainmap,hierarchy]&)/@temp1[[1;;All,1]];,{i,Length[result]}];result];
 
 
 (* ::Subsubsection:: *)


### PR DESCRIPTION
fix the bug in FindRepPathPartition such that it will not preserve any groups of particles not in the input partition.
fix the bug in GaugeJBasis such that it evaluates and simplify the symbolic tensors in stemp.